### PR TITLE
Remove `logging.basicConfig()` to avoid conflict with clients

### DIFF
--- a/devicecheck/decorators.py
+++ b/devicecheck/decorators.py
@@ -8,7 +8,6 @@ from . import DeviceCheck, AppleException
 from .asyncio import AsyncioDeviceCheck
 
 log = logging.getLogger('devicecheck:decorator')
-logging.basicConfig()
 
 if os.environ.get('DEBUG') == 'True':
     log.setLevel(logging.DEBUG)  # pragma: no cover


### PR DESCRIPTION
Calling `logging.basicConfig()` causes duplicate logging in client code. This is because clients that import `devicecheck` before setting up their own log handlers will end up with two log handlers.

Here's a simple repro: https://github.com/athyuttamre/devicecheck-repro

This PR removes this line from the package.